### PR TITLE
change console.log to console.info

### DIFF
--- a/packages/cra-template-pwa-typescript/template/src/serviceWorkerRegistration.ts
+++ b/packages/cra-template-pwa-typescript/template/src/serviceWorkerRegistration.ts
@@ -44,7 +44,7 @@ export function register(config?: Config) {
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
-          console.log(
+          console.info(
             'This web app is being served cache-first by a service ' +
               'worker. To learn more, visit https://cra.link/PWA'
           );
@@ -72,7 +72,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
+              console.info(
                 'New content is available and will be used when all ' +
                   'tabs for this page are closed. See https://cra.link/PWA.'
               );
@@ -85,7 +85,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.info('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -125,7 +125,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.');
+      console.info('No internet connection found. App is running in offline mode.');
     });
 }
 

--- a/packages/cra-template-pwa/template/src/serviceWorkerRegistration.js
+++ b/packages/cra-template-pwa/template/src/serviceWorkerRegistration.js
@@ -39,7 +39,7 @@ export function register(config) {
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
-          console.log(
+          console.info(
             'This web app is being served cache-first by a service ' +
               'worker. To learn more, visit https://cra.link/PWA'
           );
@@ -67,7 +67,7 @@ function registerValidSW(swUrl, config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
+              console.info(
                 'New content is available and will be used when all ' +
                   'tabs for this page are closed. See https://cra.link/PWA.'
               );
@@ -80,7 +80,7 @@ function registerValidSW(swUrl, config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.info('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -120,7 +120,7 @@ function checkValidServiceWorker(swUrl, config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.');
+      console.info('No internet connection found. App is running in offline mode.');
     });
 }
 


### PR DESCRIPTION
In my code I use console.info for any logs that are meant to stick around. Would a change from console.log to console.info be helpful to anyone else?