### PR TITLE
fix(template): add missing dependencies

### DIFF
--- a/packages/cra-template-pwa-typescript/template.json
+++ b/packages/cra-template-pwa-typescript/template.json
@@ -1,6 +1,10 @@
 {
   "package": {
     "dependencies": {
+      "@types/react": "^16.9.49",
+      "@types/react-dom": "^16.9.8",
+      "typescript": "^4.0.2",
+      "web-vitals": "^0.2.4",
       "workbox-background-sync": "^5.1.3",
       "workbox-broadcast-update": "^5.1.3",
       "workbox-cacheable-response": "^5.1.3",

--- a/packages/cra-template-pwa/template.json
+++ b/packages/cra-template-pwa/template.json
@@ -1,6 +1,7 @@
 {
   "package": {
     "dependencies": {
+      "web-vitals": "^0.2.4",
       "workbox-background-sync": "^5.1.3",
       "workbox-broadcast-update": "^5.1.3",
       "workbox-cacheable-response": "^5.1.3",


### PR DESCRIPTION
For TypeScript version, after running

```sh
npx create-react-app my-app --template cra-template-pwa-typescript
```

missed these four files currently in able for the app to run:

```json
"@types/react": "^16.9.49",
"@types/react-dom": "^16.9.8",
"typescript": "^4.0.2",
"web-vitals": "^0.2.4",
```

For JavaScript version, after running

```sh
npx create-react-app my-app --template cra-template-pwa
```

missed these one file currently in able for the app to run:

```json
"web-vitals": "^0.2.4",
```