### PR TITLE
Fix service worker onUpdate not triggering if page load was interrupted

### DIFF
--- a/packages/cra-template-pwa-typescript/template/src/serviceWorkerRegistration.ts
+++ b/packages/cra-template-pwa-typescript/template/src/serviceWorkerRegistration.ts
@@ -95,6 +95,26 @@ function registerValidSW(swUrl: string, config?: Config) {
           }
         };
       };
+
+      // in the case a page is loaded an a service worker is already waiting
+      // we should trigger the onUpdate callback
+      const waitingWorker = registration.waiting;
+      if (waitingWorker) {
+        if (navigator.serviceWorker.controller && waitingWorker.state === 'installed') {
+          // At this point, the updated precached content has been fetched,
+          // but the previous service worker will still serve the older
+          // content until all client tabs are closed.
+          console.log(
+            'New content is available and will be used when all ' +
+              'tabs for this page are closed. See https://cra.link/PWA.'
+          );
+
+          // Execute callback
+          if (config && config.onUpdate) {
+            config.onUpdate(registration);
+          }
+        }
+      }
     })
     .catch((error) => {
       console.error('Error during service worker registration:', error);

--- a/packages/cra-template-pwa/template/src/serviceWorkerRegistration.js
+++ b/packages/cra-template-pwa/template/src/serviceWorkerRegistration.js
@@ -90,6 +90,26 @@ function registerValidSW(swUrl, config) {
           }
         };
       };
+
+      // in the case a page is loaded an a service worker is already waiting
+      // we should trigger the onUpdate callback
+      const waitingWorker = registration.waiting;
+      if (waitingWorker) {
+        if (navigator.serviceWorker.controller && waitingWorker.state === 'installed') {
+          // At this point, the updated precached content has been fetched,
+          // but the previous service worker will still serve the older
+          // content until all client tabs are closed.
+          console.log(
+            'New content is available and will be used when all ' +
+              'tabs for this page are closed. See https://cra.link/PWA.'
+          );
+
+          // Execute callback
+          if (config && config.onUpdate) {
+            config.onUpdate(registration);
+          }
+        }
+      }
     })
     .catch((error) => {
       console.error('Error during service worker registration:', error);


### PR DESCRIPTION
We need to handle the case when a page is loaded and a service worker is already "waiting".

To me this happens randomly when you least expect, but one way to reproduce this issue is to open the page, 
see that service worker is beginning to download and close / reload the page. 

It seems that Chrome finishes the SW load even if you close the page. In this case on the next page load it's `waiting` and not `installing`, which means the
`registration.waiting.postMessage({ type: "SKIP_WAITING" })` trick won't work.