### PR TITLE
fix(template): update devDependencies

### DIFF
--- a/packages/cra-template-pwa-typescript/template.json
+++ b/packages/cra-template-pwa-typescript/template.json
@@ -1,14 +1,6 @@
 {
   "package": {
     "dependencies": {
-      "@testing-library/jest-dom": "^5.11.4",
-      "@testing-library/react": "^11.1.0",
-      "@testing-library/user-event": "^12.1.10",
-      "@types/node": "^12.0.0",
-      "@types/react": "^16.9.53",
-      "@types/react-dom": "^16.9.8",
-      "@types/jest": "^26.0.15",
-      "typescript": "^4.0.3",
       "web-vitals": "^0.2.4",
       "workbox-background-sync": "^5.1.3",
       "workbox-broadcast-update": "^5.1.3",
@@ -22,6 +14,16 @@
       "workbox-routing": "^5.1.3",
       "workbox-strategies": "^5.1.3",
       "workbox-streams": "^5.1.3"
+    },
+    "devDependencies": {
+      "@testing-library/jest-dom": "^5.11.4",
+      "@testing-library/react": "^11.1.0",
+      "@testing-library/user-event": "^12.1.10",
+      "@types/node": "^12.0.0",
+      "@types/react": "^16.9.53",
+      "@types/react-dom": "^16.9.8",
+      "@types/jest": "^26.0.15",
+      "typescript": "^4.0.3"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]

--- a/packages/cra-template-pwa/template.json
+++ b/packages/cra-template-pwa/template.json
@@ -1,9 +1,6 @@
 {
   "package": {
     "dependencies": {
-      "@testing-library/jest-dom": "^5.11.4",
-      "@testing-library/react": "^11.1.0",
-      "@testing-library/user-event": "^12.1.10",
       "web-vitals": "^0.2.4",
       "workbox-background-sync": "^5.1.3",
       "workbox-broadcast-update": "^5.1.3",
@@ -17,6 +14,11 @@
       "workbox-routing": "^5.1.3",
       "workbox-strategies": "^5.1.3",
       "workbox-streams": "^5.1.3"
+    },
+    "devDependencies": {
+      "@testing-library/jest-dom": "^5.11.4",
+      "@testing-library/react": "^11.1.0",
+      "@testing-library/user-event": "^12.1.10"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]


### PR DESCRIPTION
I've used this template a few times and needed to manually move these dependencies over, so I thought I'd update the template for the next person.

All testing and TypeScript dependencies should be in `devDependencies`. I'm not too sure if any of the `workbox` dependencies can move over, so I figured I'd leave them as is.