### PR TITLE
Add regex to match file extension in image caching

### DIFF
--- a/packages/cra-template-pwa/template/src/service-worker.js
+++ b/packages/cra-template-pwa/template/src/service-worker.js
@@ -48,9 +48,9 @@ registerRoute(
 
 // An example runtime caching route for requests that aren't handled by the
 // precache, in this case same-origin .png requests like those from in public/
-registerRoute(
-  // Add in any other file extensions or routing criteria as needed.
-  ({ url }) => url.origin === self.location.origin && url.pathname.endsWith('.png'), // Customize this strategy as needed, e.g., by changing to CacheFirst.
+registerRoute
+  // Add in any other file extensions by including the necessary file extension name in the regex, ex. (jpg|png|gif).
+  ({ url }) => url.origin === self.location.origin && /^.*\.(jpg|png)$/i.test(url.pathname), // Customize this strategy as needed, e.g., by changing to CacheFirst.
   new StaleWhileRevalidate({
     cacheName: 'images',
     plugins: [


### PR DESCRIPTION
The current way that the pathname in caching images was problematic, because it was impossible to add multiple file extensions on the endsWith string method. This makes it way easier to just include other file extensions. As I wrote in the comment above the changed line, you can  add in any other file extensions by including the necessary file extension name in the regex, ex. (jpg|png|gif).